### PR TITLE
Add concurrent server: puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'feedjira'
+gem 'puma'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     pg (0.18.4)
+    puma (2.16.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -214,6 +215,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   pg (~> 0.15)
+  puma
   rails (= 4.2.5)
   rspec-rails
   sass-rails (~> 5.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Backend:
 
 - Ruby
 - PostgreSQL
+- Puma Server
 
 To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [ruby-install](https://github.com/postmodern/ruby-install).
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,17 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end
+
+# Need to set threads on heroku?


### PR DESCRIPTION
Adds Puma as default webserver.

Defaults set in config/puma.rb set local host as previous deafult on port 3000 and should be automatically detected on next push to heroku so, no additional setup would be needed.