### PR TITLE
Travis CI continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - 2.3.0
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+script: bundle exec rspec
+after_success: coveralls

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.3.0'
+
 gem 'rails', '4.2.5'
 gem 'pg', '~> 0.15'
 gem 'sass-rails', '~> 5.0'
@@ -17,6 +19,7 @@ gem 'newrelic_rpm'
 gem 'figaro'
 gem 'will_paginate-bootstrap'
 gem 'draper'
+gem 'coveralls', require: false
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,10 +67,17 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.0)
+    coveralls (0.8.13)
+      json (~> 1.8)
+      simplecov (~> 0.11.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (~> 1.6.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     draper (2.1.0)
       actionpack (>= 3.0)
       activemodel (>= 3.0)
@@ -193,6 +200,11 @@ GEM
       rdoc (~> 4.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -206,9 +218,12 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
+    tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -239,6 +254,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
+  coveralls
   draper
   factory_girl_rails
   faker
@@ -264,4 +280,4 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
+[![Build Status](https://travis-ci.org/PenneyGadget/lookingfor.svg?branch=master)](https://travis-ci.org/PenneyGadget/lookingfor)
+
+# LookingFor
+
 ## Description
-LookingFor is a rails application that pull developer job postings from the internet and uses them to answer the question 'Hello, is it me you're looking for?'
+LookingFor is a rails application that pulls developer job postings from the internet and uses them to answer the question "Hello, is it me you're looking for?"
 
 [Visit the App in Production](https://lookingforme.herokuapp.com/)
 
@@ -34,8 +38,27 @@ If you're on a Linux system with apt-get then run: `apt-get install postgresql p
 
 ### Run The Application
 
+* Make sure you have bundled with: `bundle install`
 * Start the server with: `bundle exec rails s`
 * Then you can access the local server at [localhost:3000](http://localhost:3000)
+
+** Note: You must be able to run ruby 2.3.0 in order to view the app locally, as that is what the Gemfile currently specifies.
+
+### Travis CI
+
+LookingFor has continuous integration enabled with the Travis CI gem. To get it running and use the command line client, run:
+
+* `gem install travis -v 1.8.2 --no-rdoc --no-ri`
+
+Make sure everything works by running:
+
+* `travis version`
+
+You can run `travis help` to see a list of all available query commands. Run `travis help <query command>` to get detailed information about a particular command.
+
+More information can be found [here](https://github.com/travis-ci/travis.rb#command-line-client) or in the [docs](https://docs.travis-ci.com/).
+
+If you have issues running tests locally after setting up Travis CI, run the command `rake db:test:prepare` and that should solve the issue.
 
 ### Testing
 1. Run the test suite: `bundle exec rspec`

--- a/config/database.yml
+++ b/config/database.yml
@@ -58,7 +58,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: lookingfor_test
+  database: travis_ci_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,12 @@
 require 'factory_girl_rails'
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+
+SimpleCov.start('rails') do
+  add_filter 'app/secrets'
+end
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
This PR implements Travis CI for continuous integration and Coveralls to report test coverage (Coveralls is compatible with Travis CI and they should communicate with each other). Once this is merged into master all team members will need to be upgraded to Ruby 2.3.0 because that is the version now specified in the Gemfile. The Gemfile also now includes instructions to install the Travis command line client and adds the Travis CI status image for the build and, hopefully, also the Coveralls test coverage report percentage. 

In theory all team members should now get and email if any tests or the build fails on a commit. There is no way for me to know the full scope of how this will function for all team members, for test coverage, for failed builds, etc. until those particular scenarios come up, but in all other respects this should be fine to merge into master.