### PR TITLE
Normalizing locations #69

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -10,7 +10,8 @@ class Job < ActiveRecord::Base
   belongs_to :location
 
   def self.by_location(search_location)
-    where("lower(location) LIKE ?", "%#{search_location.downcase}%")
+    # where("lower(location) LIKE ?", "%#{search_location.downcase}%")
+    joins(:location).where("lower(name) LIKE ?", "%#{search_location.downcase}%")
   end
 
   def downcase_tech

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -11,6 +11,7 @@ class Job < ActiveRecord::Base
 
   def self.by_location(search_location)
     # where("lower(location) LIKE ?", "%#{search_location.downcase}%")
+    # binding.pry
     joins(:location).where("lower(name) LIKE ?", "%#{search_location.downcase}%")
   end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -5,6 +5,7 @@ class Job < ActiveRecord::Base
   scope :by_date, -> { order(posted_date: :desc) }
   belongs_to :company
   has_and_belongs_to_many :technologies
+  belongs_to :location
 
   def downcase_tech
     self.raw_technologies = self.raw_technologies.compact.map(&:downcase)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,4 @@
+class Location < ActiveRecord::Base
+  validates :name, presence: true, uniqueness: true
+  has_many :jobs
+end

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -4,7 +4,7 @@ class JobSerializer < ActiveModel::Serializer
   has_many :technologies
 
   def location
-    object.location.name
+    object.location.name if object.location
   end
 
 end

--- a/app/serializers/job_serializer.rb
+++ b/app/serializers/job_serializer.rb
@@ -1,4 +1,8 @@
 class JobSerializer < ActiveModel::Serializer
   attributes :title, :description, :url, :location, :posted_date, :remote, :raw_technologies
   has_one :company
+
+  def location
+    object.location.name
+  end
 end

--- a/app/services/authentic_jobs_service.rb
+++ b/app/services/authentic_jobs_service.rb
@@ -15,7 +15,6 @@ class AuthenticJobsService < JobFetcher
     { job: {
         title: self.full_title(entry),
         url: entry[:url],
-        location: self.pull_location(entry),
         raw_technologies: self.pull_technologies(entry[:description], term),
         description: entry[:description],
         remote: entry[:telecommuting] == 1 ? true : false,
@@ -23,6 +22,9 @@ class AuthenticJobsService < JobFetcher
       },
       company: {
         name: self.pull_company_name(entry)
+      },
+      location: {
+        name: self.pull_location(entry)
       }
     }
   end

--- a/app/services/job_fetcher.rb
+++ b/app/services/job_fetcher.rb
@@ -5,8 +5,8 @@ class JobFetcher
 
   def self.create_records(entry)
     company = self.find_or_create_company(entry[:company])
-    #location = self.find_or_create_location()
-    self.create_job(entry[:job], company)
+    location = self.find_or_create_location(entry[:location])
+    self.create_job(entry[:job], company, location)
   end
 
   def self.find_or_create_company(company)
@@ -14,12 +14,16 @@ class JobFetcher
       .first_or_create(name: company[:name])
   end
 
-  def self.find_or_create_location()
+  def self.find_or_create_location(location)
+    Location.where('lower(name) = ?', location[:name].downcase)
+      .first_or_create(name: location[:name])
   end
 
-  def self.create_job(job_attributes, company)
+  def self.create_job(job_attributes, company, location)
     job = company.jobs.where(title: job_attributes[:title])
       .first_or_create(job_attributes)
+
+    location.jobs << job if job
     job.assign_tech if job
   end
 

--- a/app/services/job_fetcher.rb
+++ b/app/services/job_fetcher.rb
@@ -5,12 +5,16 @@ class JobFetcher
 
   def self.create_records(entry)
     company = self.find_or_create_company(entry[:company])
+    #location = self.find_or_create_location()
     self.create_job(entry[:job], company)
   end
 
   def self.find_or_create_company(company)
     Company.where('lower(name) = ?', company[:name].downcase)
       .first_or_create(name: company[:name])
+  end
+
+  def self.find_or_create_location()
   end
 
   def self.create_job(job_attributes, company)

--- a/app/services/stack_overflow.rb
+++ b/app/services/stack_overflow.rb
@@ -29,7 +29,7 @@ class StackOverflow < JobFetcher
     { job: {
         title: title,
         url: url_address,
-        location: location,
+        old_location: location,
         raw_technologies: generate_raw_technologies(entry), #["perl", "python", "ruby", "or-go.-ruby-and", "or-go-experience-is-stron"],
         description: description,
         remote: self.is_remote?(title),

--- a/app/services/stack_overflow.rb
+++ b/app/services/stack_overflow.rb
@@ -25,7 +25,6 @@ class StackOverflow < JobFetcher
     { job: {
         title: entry.title,
         url: entry.url,
-        location: self.pull_location(entry.title),
         raw_technologies: generate_raw_technologies(entry), #["perl", "python", "ruby", "or-go.-ruby-and", "or-go-experience-is-stron"],
         description: entry.summary,
         remote: self.is_remote?(entry.title),
@@ -33,7 +32,10 @@ class StackOverflow < JobFetcher
       },
       company: {
         name: self.pull_company_name(entry.title)
-      }
+      },
+      location: {
+        name: self.pull_location(entry.title),
+      },
     }
   end
 

--- a/app/services/we_work_remotely.rb
+++ b/app/services/we_work_remotely.rb
@@ -27,7 +27,6 @@ class WeWorkRemotely < JobFetcher
     { job: {
         title: entry.title,
         url: entry.url,
-        location: self.pull_location(summary),
         raw_technologies: self.pull_technologies(description),
         description: description,
         remote: true,
@@ -35,6 +34,9 @@ class WeWorkRemotely < JobFetcher
       },
       company: {
         name: self.pull_company_name(entry.title)
+      },
+      location: {
+        name: self.pull_location(summary),
       }
     }
   end

--- a/db/migrate/20160601222310_change_location_to_old_location_on_jobs.rb
+++ b/db/migrate/20160601222310_change_location_to_old_location_on_jobs.rb
@@ -1,0 +1,5 @@
+class ChangeLocationToOldLocationOnJobs < ActiveRecord::Migration
+  def change
+    rename_column :jobs, :location, :old_location
+  end
+end

--- a/db/migrate/20160601222932_create_locations.rb
+++ b/db/migrate/20160601222932_create_locations.rb
@@ -1,0 +1,9 @@
+class CreateLocations < ActiveRecord::Migration
+  def change
+    create_table :locations do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160601223043_add_location_to_jobs.rb
+++ b/db/migrate/20160601223043_add_location_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddLocationToJobs < ActiveRecord::Migration
+  def change
+    add_reference :jobs, :location, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160214194929) do
+ActiveRecord::Schema.define(version: 20160601223043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "companies", force: :cascade do |t|
     t.string   "name",       null: false
@@ -26,20 +27,28 @@ ActiveRecord::Schema.define(version: 20160214194929) do
     t.string   "title",                         null: false
     t.text     "description"
     t.string   "url"
-    t.string   "location"
+    t.string   "old_location"
     t.date     "posted_date"
     t.boolean  "remote"
     t.text     "raw_technologies", default: [],              array: true
     t.integer  "company_id"
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
+    t.integer  "location_id"
   end
 
   add_index "jobs", ["company_id"], name: "index_jobs_on_company_id", using: :btree
+  add_index "jobs", ["location_id"], name: "index_jobs_on_location_id", using: :btree
 
   create_table "jobs_technologies", id: false, force: :cascade do |t|
     t.integer "technology_id"
     t.integer "job_id"
+  end
+
+  create_table "locations", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "technologies", force: :cascade do |t|
@@ -49,4 +58,5 @@ ActiveRecord::Schema.define(version: 20160214194929) do
   end
 
   add_foreign_key "jobs", "companies"
+  add_foreign_key "jobs", "locations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20160601223043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "companies", force: :cascade do |t|
     t.string   "name",       null: false

--- a/lib/tasks/one_off_tasks/fix_location.rake
+++ b/lib/tasks/one_off_tasks/fix_location.rake
@@ -12,7 +12,7 @@ namespace :fix_location do
         check_for_location(job)
       else
         response = Geocoder.search(job.old_location)
-        sleep 2
+        sleep 0.5
         if response.empty? || response.count > 1 || check_edge_cases(job.old_location)
           check_for_location(job)
         end
@@ -25,7 +25,7 @@ namespace :fix_location do
     potential_locations = job.title.scan(regex).flatten
     potential_locations.each do |p_loc|
       response = Geocoder.search(p_loc)
-      sleep 2
+      sleep 0.5
       if !response.empty? && response.count == 1 && !check_edge_cases(p_loc)
         return job.update_attributes(old_location: p_loc)
       else

--- a/lib/tasks/one_off_tasks/fix_location.rake
+++ b/lib/tasks/one_off_tasks/fix_location.rake
@@ -8,12 +8,12 @@ namespace :fix_location do
   def jobs_with_locations
     stackoverflow_jobs = Job.where('url LIKE ?', '%stackoverflow%')
     stackoverflow_jobs.each do |job|
-      if job.location.nil?
+      if job.old_location.nil?
         check_for_location(job)
       else
-        response = Geocoder.search(job.location)
+        response = Geocoder.search(job.old_location)
         sleep 2
-        if response.empty? || response.count > 1 || check_edge_cases(job.location)
+        if response.empty? || response.count > 1 || check_edge_cases(job.old_location)
           check_for_location(job)
         end
       end
@@ -27,9 +27,9 @@ namespace :fix_location do
       response = Geocoder.search(p_loc)
       sleep 2
       if !response.empty? && response.count == 1 && !check_edge_cases(p_loc)
-        return job.update_attributes(location: p_loc)
+        return job.update_attributes(old_location: p_loc)
       else
-        job.update_attributes(location: nil)
+        job.update_attributes(old_location: nil)
       end
     end
   end

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::JobsController, type: :controller do
   describe "GET #index" do
-    let(:response_body) { json_respone = JSON.parse(response.body) }
+    let(:response_body) { JSON.parse(response.body) }
 
     it "is successful" do
       get :index, format: :json

--- a/spec/controllers/api/v1/recent_jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/recent_jobs_controller_spec.rb
@@ -61,11 +61,14 @@ RSpec.describe Api::V1::RecentJobsController, type: :controller do
 
     it 'returns correct number of jobs for location search' do
       job1 = create(:job)
-      job1.update(location: "DENVER")
+      job1.location.update_attributes(name: "DENVER")
+
       job2 = create(:job)
-      job2.update(location: "DENVER")
+      job2.location.update_attributes(name: "DENVEr")
+
       job3 = create(:job)
-      job3.update(location: "Hawaii")
+      job3.location.update_attributes(name: "Hawaii")
+
       get :index, { location: "Denver" }, format: :json
 
       expect(response_body['recent_jobs'].count).to eq(2)
@@ -83,11 +86,15 @@ RSpec.describe Api::V1::RecentJobsController, type: :controller do
 
     it 'only returns jobs posted within the last month when searching by location' do
       two_month_job = create(:job)
-      two_month_job.update(location: "DENVER", posted_date: 2.months.ago)
+      two_month_job.update_attributes(posted_date: 2.months.ago)
+      two_month_job.location.update_attributes(name: "DENVER")
+
       one_month_job = create(:job)
-      one_month_job.update(location: "DENVER", posted_date: 1.month.ago)
+      one_month_job.update_attributes(posted_date: 1.months.ago)
+      one_month_job.location.update_attributes(name: "DENVer")
+      
       current_job = create(:job)
-      current_job.update(location: "DENVER")
+      current_job.location.update_attributes(name: "DENVEr")
 
       get :index, { location: "Denver" }, format: :json
 

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     sequence(:title, 1) { |n| [Faker::Company.profession, n].join }
     description { Faker::Company.bs }
     url { Faker::Internet.url }
-    location { Faker::Address.city }
+    location
     posted_date { Faker::Date.between(2.days.ago, Date.today) }
     raw_technologies { [[Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),
                       [Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -3,7 +3,8 @@ FactoryGirl.define do
     sequence(:title, 1) { |n| [Faker::Company.profession, n].join }
     description { Faker::Company.bs }
     url { Faker::Internet.url }
-    location 
+    old_location { nil }
+    location
     posted_date { Faker::Date.between(2.days.ago, Date.today) }
     raw_technologies { [[Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),
                       [Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),
@@ -16,6 +17,7 @@ FactoryGirl.define do
     sequence(:title, 1) { |n| [Faker::Company.profession, n].join }
     description { Faker::Company.bs }
     url { "stackoverflow" }
+    old_location { nil }
     location
     posted_date { Faker::Date.between(2.days.ago, Date.today) }
     raw_technologies { [[Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     sequence(:title, 1) { |n| [Faker::Company.profession, n].join }
     description { Faker::Company.bs }
     url { Faker::Internet.url }
-    location { "New York, NY" }
+    location 
     posted_date { Faker::Date.between(2.days.ago, Date.today) }
     raw_technologies { [[Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),
                       [Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),
@@ -16,7 +16,7 @@ FactoryGirl.define do
     sequence(:title, 1) { |n| [Faker::Company.profession, n].join }
     description { Faker::Company.bs }
     url { "stackoverflow" }
-    location { nil }
+    location
     posted_date { Faker::Date.between(2.days.ago, Date.today) }
     raw_technologies { [[Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),
                       [Faker::Hacker.adjective, Faker::Hacker.noun].join(' '),

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :location do
+    sequence(:name, 1) { |n| [Faker::Address.city, n].join }
+  end
+end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -32,24 +32,23 @@ describe Job do
   end
 
   it "can search by location case insensitive" do
-    two_month_job = create(:job)
-    # binding.pry
-    two_month_job.location.name = "DENVER"
-    one_month_job = create(:job)
-    one_month_job.location.name = "DENVER"
-    current_job = create(:job)
-    current_job.location.name = "Florida"
+    jobs = create_list(:job, 3)
+
+    jobs[0].location.update_attributes(name: "DENVER")
+    jobs[1].location.update_attributes(name: "DenveR")
+    jobs[2].location.update_attributes(name: "Florida")
+
     results = Job.by_location("Denver")
     expect(results.count).to eq(2)
   end
 
   it "can search by location case partial match" do
-    two_month_job = create(:job)
-    two_month_job.location.name = "DENVER, CO"
-    one_month_job = create(:job)
-    one_month_job.location.name = "DENVER, COLORADO"
-    current_job = create(:job)
-    current_job.location.name = "Denver is the coolest place ever"
+    jobs = create_list(:job, 3)
+
+    jobs[0].location.update_attributes(name: "DENVER, CO")
+    jobs[1].location.update_attributes(name: "DENVER, COLORADO")
+    jobs[2].location.update_attributes(name: "Denver is the kewlest place ever")
+    
     results = Job.by_location("Denver")
     expect(results.count).to eq(3)
   end
@@ -88,8 +87,8 @@ describe Job do
 
   describe 'geocodes' do
     it 'uses geocoder to fetch lat and long coordinates' do
-      job = Job.create(location: "1510 Blake Street Denver CO")
-      coords = Geocoder.search(job.location).first.data
+      job = Job.create(old_location: "1510 Blake Street Denver CO")
+      coords = Geocoder.search(job.old_location).first.data
 
       expect(coords['latitude']).to eq(40.7143528)
       expect(coords['longitude']).to eq(-74.0059731)

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -15,6 +15,7 @@ describe Job do
 
   describe "Associations" do
     it { expect(instance).to belong_to(:company) }
+    it { expect(instance).to belong_to(:location) }
     it { expect(instance).to have_and_belong_to_many(:technologies) }
   end
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -33,22 +33,23 @@ describe Job do
 
   it "can search by location case insensitive" do
     two_month_job = create(:job)
-    two_month_job.update(location: "DENVER")
+    # binding.pry
+    two_month_job.location.name = "DENVER"
     one_month_job = create(:job)
-    one_month_job.update(location: "DENVER")
+    one_month_job.location.name = "DENVER"
     current_job = create(:job)
-    current_job.update(location: "Florida")
+    current_job.location.name = "Florida"
     results = Job.by_location("Denver")
     expect(results.count).to eq(2)
   end
 
   it "can search by location case partial match" do
     two_month_job = create(:job)
-    two_month_job.update(location: "DENVER, CO")
+    two_month_job.location.name = "DENVER, CO"
     one_month_job = create(:job)
-    one_month_job.update(location: "DENVER, COLORADO")
+    one_month_job.location.name = "DENVER, COLORADO"
     current_job = create(:job)
-    current_job.update(location: "Denver is the coolest place ever")
+    current_job.location.name = "Denver is the coolest place ever"
     results = Job.by_location("Denver")
     expect(results.count).to eq(3)
   end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Location, type: :model do
+  it "has a valid factory" do
+    expect(build(:location)).to be_valid
+  end
+
+  let(:instance) { build(:location) }
+  describe "Validations" do
+    it { expect(instance).to validate_presence_of(:name) }
+    it { expect(instance).to validate_uniqueness_of(:name) }
+  end
+
+  describe "Associations" do
+    it { expect(instance).to have_many(:jobs) }
+  end
+
+end

--- a/spec/services/authentic_jobs_service_spec.rb
+++ b/spec/services/authentic_jobs_service_spec.rb
@@ -85,7 +85,6 @@ describe AuthenticJobsService do
       formatted_entry = { job: {
           title: "Web Developer at Chalk (Denver, CO, US)",
           url: "https://authenticjobs.com/jobs/27094/web-developer",
-          location: "Denver, CO, US",
           raw_technologies: ['ruby'],
           description: "<p><p>We’re a two person partnership located in the oh-so-hip RiNo area of Denver, where we’ve been quietly creating usable and maintainable interactive solutions for our clients. If you’ve ever wanted to be that guy or gal people at the office point at in awe, while uttering the magical phrase, “that's employee number one” - this job’s for you.</p><p>We’re looking for a front-end developer that can make our designs a reality. Under the tutelage of our senior developer, you will use HTML, CSS and Javascript to take a project from hi-fi comps to a fully functioning solution.</p><p>While we’re sure you’re a simply lovely person, <strong>we need to make sure you have a few qualifications first</strong>:</p><ul><li>1+ years development experience.</li><li>Knowledge of standards-compliant HTML5 and CSS3, including responsive design techniques.</li><li>Some familiarity with JavaScript and a smattering of libraries - e.g., jQuery or Underscore/LoDash, etc.</li><li>Familiarity with version control tools (we use Git).</li><li>Ability to perform QA on a myriad of devices with differing screen sizes and resolutions.</li><li>Interest in your career as a craft - this includes researching new technologies, and perfecting your use of current ones.</li><li>Ability to communicate well with both internal team members and external stakeholders.</li></ul><p>That’s the gist of things, <strong>but the following certainly wouldn’t hurt</strong>:</p><ul><li>Familiarity with some server-side technologies. PHP and/or Ruby comes to mind.</li><li>Familiarity with Sketch and/or Photoshop.</li><li>Familiarity with CMS platforms (e.g., Wordpress).</li><li>Familiarity with SEO techniques.</li></ul><p>We have a flexible work schedule, will provide you with a shiny new Macbook Pro and some pretty posh digs for you to do your thing. If this sounds like your jam, send over your resumé and, (if you have one) your github username. The location of any past projects you worked on would be helpful as well. </p><p>We’re looking forward to working together!</p></p>",
           remote: false,
@@ -93,6 +92,9 @@ describe AuthenticJobsService do
         },
         company: {
           name: "Chalk"
+        },
+        location: {
+          name: "Denver, CO, US"
         }
       }
 

--- a/spec/services/job_fetcher_spec.rb
+++ b/spec/services/job_fetcher_spec.rb
@@ -5,14 +5,17 @@ describe JobFetcher do
     job: {
       title: "Node Instrumentation Engineer at New Relic (Portland, OR)",
       url: "http://stackoverflow.com/jobs/109010/node-instrumentation-engineer-new-relic",
-      location: "Portland Oregon",
+
       raw_technologies: ["c++", "python", "java", "php", "ruby"],
       description: "<p><strong>New Relic<br></strong><strong>",
       remote: false,
       posted_date: "2016-02-15 16:52:38 UTC" },
     company: {
       name: "New Relic"
-    }
+    },
+    location: {
+      name: "Portland Oregon"
+    },
   }}
 
   let(:subject){ JobFetcher }
@@ -65,7 +68,6 @@ describe JobFetcher do
         expect(job.title).to eq(job_entry[:title])
         expect(job.description).to eq(job_entry[:description])
         expect(job.url).to eq(job_entry[:url])
-        expect(job.location).to eq(job_entry[:location])
         expect(job.raw_technologies).to eq(job_entry[:raw_technologies])
         expect(job.remote).to eq(job_entry[:remote])
         expect(job.posted_date).to eq(job_entry[:posted_date].to_date)

--- a/spec/tasks/location_rake_task_spec.rb
+++ b/spec/tasks/location_rake_task_spec.rb
@@ -42,42 +42,42 @@ describe "fix_locations:jobs" do
   it "will update job location with correct location" do
     create(:stackoverflow_job, title: "Junior Dev position (#{valid_tech1}) (#{valid_location})")
 
-    expect(Job.all.last.location).to eq(nil)
+    expect(Job.all.last.old_location).to eq(nil)
 
     subject.invoke
 
-    expect(Job.all.last.location).to eq("#{valid_location}")
+    expect(Job.all.last.old_location).to eq("#{valid_location}")
   end
 
   it "will not overwrite job locations" do
     create(:stackoverflow_job, title: "Junior Dev position (#{valid_tech1}) (#{valid_location}) (#{valid_tech2})")
 
-    expect(Job.all.last.location).to eq(nil)
+    expect(Job.all.last.old_location).to eq(nil)
 
     subject.invoke
 
-    expect(Job.all.last.location).to eq("#{valid_location}")
+    expect(Job.all.last.old_location).to eq("#{valid_location}")
   end
 
   it "will make location nil if no valid locations are present" do
     create(:stackoverflow_job, title: "Junior Dev position (#{valid_tech1}) (#{valid_tech2})",
-                               location: "#{valid_tech1}")
+                               old_location: "#{valid_tech1}")
 
-    expect(Job.all.last.location).to eq("#{valid_tech1}")
+    expect(Job.all.last.old_location).to eq("#{valid_tech1}")
 
     subject.invoke
 
-    expect(Job.all.last.location).to eq(nil)
+    expect(Job.all.last.old_location).to eq(nil)
   end
 
   it "will not change location if no parentheses available in title" do
     create(:stackoverflow_job, title: "Junior Dev position",
-                               location: "#{valid_tech1}")
+                               old_location: "#{valid_tech1}")
 
-    expect(Job.all.last.location).to eq("#{valid_tech1}")
+    expect(Job.all.last.old_location).to eq("#{valid_tech1}")
 
     subject.invoke
 
-    expect(Job.all.last.location).to eq("#{valid_tech1}")
+    expect(Job.all.last.old_location).to eq("#{valid_tech1}")
   end
 end


### PR DESCRIPTION
This normalizes the information from location column on the jobs table. Location is now implemented as a separate model with a single field, name.

* Added a migration to move current location information into a different column called old_location.
* Added location model
* Created a location_id column on the Jobs model to refer to a single location: Locations have many jobs and jobs belong to a location
* Changed the job factory to reflect the association with location
* Added a location factory
* JobFetcher now expects that the entry hash has a location field (similar to category), removed location from the jobs field
  * Raw entry in tests modified to reflect this change.
* Added additional tests for job fetcher
* All feature/model tests pass

Outstanding issues:
[ ] Waiting on #37 to be sorted out to convert old_locations to a location (rake task)
[ ] After above is handled, a migration will remove old_locations from the jobs table
[ ] Looking at some of the entries, we will have to smartly parse the locations. One challenge is that foreign countries may come in as full descriptions and from another service is referred by abbreviation: e.g. London, UK and London, United Kingdom and these should be parse to the same location. Another example is dealing with the fact that some US locations also have US or USA appended to the end. Another thing to think about is that multiple locations may be parsed from a job listing.

Any thoughts? @rrgayhart @NickyBobby @brennanholtzclaw @hhoopes 
