### PR TITLE
Add rack-cors gem and configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'will_paginate-bootstrap'
 gem 'draper'
 gem 'faraday'
 gem 'coveralls', require: false
+gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
       slop (~> 3.4)
     puma (2.16.0)
     rack (1.6.4)
+    rack-cors (0.4.0)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -268,6 +269,7 @@ DEPENDENCIES
   pg (~> 0.15)
   pry
   puma
+  rack-cors
   rails (= 4.2.5)
   rspec-rails
   sass-rails (~> 5.0)
@@ -280,5 +282,8 @@ DEPENDENCIES
   webmock
   will_paginate-bootstrap
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,16 @@ module Lookingfor
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    config.middleware.insert_before 0, "Rack::Cors", :debug => true, :logger => (-> { Rails.logger }) do
+      allow do
+        origins '*'
+        resource '*',
+          :headers => :any,
+          :methods => [:get],
+          :max_age => 0
+      end
+    end
+
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
   end


### PR DESCRIPTION
* Added rack-cors [gem](https://github.com/cyu/rack-cors) to enable AJAX requests to the API
* Since there is a single API endpoint GET /api/v1/jobs, this only enables CORS for get requests
* The configuration is taken from the README as well as the [Rails 4 example](https://github.com/cyu/rack-cors/tree/master/examples/rails4)
* @ksk5280 and @cheljoh confirmed that the clone deployment I had up did enable them to make AJAX requests from their client

closes #73 
@rrgayhart @brennanholtzclaw @hhoopes @NickyBobby