### PR TITLE
9 database load testing --would like to pull location into my seeds before merging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ group :development, :test do
   gem 'byebug'
   gem 'pry'
   gem 'faker'
+  gem 'rails-perftest'
+  gem 'ruby-prof'
+  gem 'poltergeist'
 end
 
 group :test do
@@ -41,4 +44,5 @@ end
 group :development do
   gem 'web-console', '~> 2.0'
   gem 'spring'
+  gem 'activerecord-import'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,8 @@ GEM
       activemodel (= 4.2.5)
       activesupport (= 4.2.5)
       arel (~> 6.0)
+    activerecord-import (0.13.0)
+      activerecord (>= 3.0)
     activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -58,6 +60,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -131,6 +134,11 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     pg (0.18.4)
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -160,6 +168,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-perftest (0.0.6)
     railties (4.2.5)
       actionpack (= 4.2.5)
       activesupport (= 4.2.5)
@@ -186,6 +195,7 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    ruby-prof (0.15.9)
     safe_yaml (1.0.4)
     sass (3.4.21)
     sass-rails (5.0.4)
@@ -238,6 +248,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     will_paginate (3.1.0)
     will_paginate-bootstrap (1.0.1)
       will_paginate (>= 3.0.3)
@@ -249,6 +262,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  activerecord-import
   api-pagination
   bootstrap-sass
   byebug
@@ -266,10 +280,13 @@ DEPENDENCIES
   launchy
   newrelic_rpm
   pg (~> 0.15)
+  poltergeist
   pry
   puma
   rails (= 4.2.5)
+  rails-perftest
   rspec-rails
+  ruby-prof
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   shoulda-matchers
@@ -280,5 +297,8 @@ DEPENDENCIES
   webmock
   will_paginate-bootstrap
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,21 +34,31 @@ if Rails.env.development?
   puts "Starting import...this will take a long time"
   Company.import(array)
 
+  array = []
+  puts "Loading Locations"
+  location_number = job_number/10
+
+  location_number.times do | i |
+    array << Location.new(name: Faker::Address.city)
+  end
+  puts "Starting import...this will take a long time"
+  Location.import(array)
 
   # load jobs
   array =[]
   puts "Loading Jobs"
   job_number.times do |i|
-    id = Random.rand(1..company_number)
+    c_id = Random.rand(1..company_number)
+    l_id = Random.rand(1..location_number)
     job_attrs = {
       title: Faker::Company.profession + i.to_s,
       description: Faker::Lorem.paragraph(15),
       url: Faker::Internet.url,
-      location: Faker::Address.city,
       posted_date: Faker::Date.between(2.days.ago, Date.today),
       remote: i % 2 == 0,
       raw_technologies: Technology.pluck(:name).shuffle.take(3),
-      company_id: id
+      company_id: c_id,
+      location_id: l_id
     }
     array << Job.new(job_attrs)
     puts "Added Job  ##{i} to the import array" if i % 1000 == 0

--- a/docs/assumptions.markdown
+++ b/docs/assumptions.markdown
@@ -1,0 +1,91 @@
+# BUSINESS ASSUMPTIONS
+
+### I believe my customers have a need to:
+
+- Find Jobs writ large
+- Find Jobs based on specific tech stacks
+- Find Jobs based on specific locations
+- Know which companies use specific tech stacks
+- Know where Turing alumni are working or have worked
+- Know when a new company using a tech stack we teach starts hiring
+- What are the trends in tech stacks over time
+- Know which companies we aren't connected with that we should be
+
+### These needs can be solved with:
+
+- Computers
+
+### My initial customers are (or will be):
+
+- Turing Students
+- Turing Staff
+- Turing Alumni
+
+### The #1 value a customer wants to get out of my service is:
+
+- Jerbs for selves or others
+
+### The customer can also get these additional benefits:
+
+- Trends for Jerbs
+
+### I will acquire the majority of my customers through:
+
+- Turing: Slacktor Beam
+
+### I will make my money by:
+
+- This is unlikely for the immediate future - but potentially partnerships with other companies who could use the service.
+
+### My primary competition in the market will be:
+
+- LinkedIn
+- HeadHunters
+- Indeed
+- Github Jobs
+- Built in Colorado
+- The jobs sites we actually scrape
+
+### We will beat them due to:
+
+- We know our audience better
+- The networking connections & community
+
+Beating them isn't a problem exactly because everything helps
+
+### My biggest product risk is:
+
+- No one using it.
+- Dramatic changes to APIs that we use.
+
+### We will solve this through:
+
+- Student Power
+- Staff Power
+- Alumni Power
+- Power
+
+Regular maintenance - good documentation - error handling
+
+### What other assumptions do we have that, if proven false, will cause our business/project to fail:
+
+- Probably that the tools students currently have aren't enough
+- Separation/Integration from turing.io?
+
+# USER ASSUMPTIONS
+
+### Who is the user?
+
+### Where does our product fit in his/her work or life?
+
+### What problems does our product solve?
+
+### When and how is our product used?
+
+### What features are important?
+
+### How should our product look and behave?
+
+
+
+`Questions From Lean UX by Jeff Gothelf`

--- a/lib/load_script/job_endpoints.rb
+++ b/lib/load_script/job_endpoints.rb
@@ -1,0 +1,64 @@
+require 'logger'
+require 'capybara'
+require 'capybara/poltergeist'
+require 'active_support'
+require 'active_support/core_ext'
+
+module LoadScript
+  class Job_Endpoints
+    attr_reader :host
+
+    def initialize(host= nil)
+      Capybara.default_driver = :poltergeist
+      @host = host || "http://localhost:3000"
+    end
+
+    def logger
+      @logger ||= Logger.new("./log/requests.log")
+    end
+
+    def session
+      @session ||= Capybara::Session.new(:poltergeist)
+    end
+
+    def run
+      puts "Running 10 iterations for data..."
+      10.times do |i|
+        puts "Running iteration #{i + 1}..."
+        run_action(actions.sample)
+      end
+    end
+
+    def run_action(name)
+      benchmark(name) do
+        send(name)
+      end
+    rescue Capybara::Poltergeist::TimeoutError
+      logger.error("Timed out executing Action: #{name}. Will continue.")
+    end
+
+    def benchmark(name)
+      logger.info "Running action #{name}"
+      start = Time.now
+      val = yield
+      logger.info "Completed #{name} in #{Time.now - start} seconds"
+      val
+    end
+
+    def actions
+      [:browse_index, :view_job]
+    end
+
+    def browse_index
+      session.visit(host)
+    end
+
+    def view_job
+      session.visit(host)
+      session.all("h4").sample.click_link_or_button("View Listing")
+    end
+
+    def view_company_jobs
+    end
+  end
+end

--- a/lib/tasks/load_script.rake
+++ b/lib/tasks/load_script.rake
@@ -1,4 +1,4 @@
-require 'load_script/session'
+require 'load_script/job_endpoints'
 
 namespace :load_script do
   desc "Run a load testing script against app. Accepts 'HOST' as an argument. Defaults to 'localhost:3000'."

--- a/lib/tasks/load_script.rake
+++ b/lib/tasks/load_script.rake
@@ -1,0 +1,8 @@
+require 'load_script/session'
+
+namespace :load_script do
+  desc "Run a load testing script against app. Accepts 'HOST' as an argument. Defaults to 'localhost:3000'."
+  task run: :environment do
+    LoadScript::Job_Endpoints.new(ARGV[1]).run
+  end
+end


### PR DESCRIPTION
The solution I eventually decided on for performance logging/tracking is the most maintainable and provides some flexibility in the development environment.

Instead of creating a staging server, a developer looking to test code can
seed the development db with `rake db:seed` (as usual), a process that will
take about 30 min to load and create 12000 companies and 30000 jobs. While this is fewer records
than the acceptance criteria, it still is an increase on what we have in
production currently and can be bumped up as our app gets bigger. Because of the
time to seed the db, I wasn't sure that any more records would be feasible for
developers shifting onto this project.

However, this allows a developer to use the new rake task `rake load_script:run`
to hit any endpoint in rapid succession, generating data to `logs/request.log`.
Additionally, we have access to New Relic data at the endpoint `localhost:3000/newrelic`.

Currently the rake task is only hitting the index and a randomly selected job listing, but
anyone can add new endpoints easily in `lib/load_script/job_endpoints` using
plain ol' Capybara.

While we may still need to decide on a better solution than New Relic for viewing production
performance data, this PR gives some flexibility and feedback right now.

Closes #9 
