### PR TITLE
Add /api/v1/jobs/:id endpoint

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -3,4 +3,10 @@ class Api::V1::JobsController < ApplicationController
   def index
     paginate json: Job.by_date, per_page: 25
   end
+
+  def show
+    @job = Job.find(params[:id])
+    render json: @job
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,10 @@ Rails.application.routes.draw do
 
   resources :jobs, only: [:show]
   resources :companies, only: [:show]
-  
+
   namespace :api do
     namespace :v1 do
-      resources :jobs, only: [:index]
+      resources :jobs, only: [:index, :show]
     end
   end
   # Example of regular route:

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
       expect(json_job['location']).to be_instance_of(String)
       expect(json_job['posted_date']).to be_instance_of(String)
       expect(json_job['remote']).to be false
-      expect(json_job['raw_technologies']).to be_instance_of(Array)
+      expect(json_job['technologies']).to be_instance_of(Array)
       expect(json_job['company']).to be_instance_of(Hash)
     end
   end

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -49,4 +49,29 @@ RSpec.describe Api::V1::JobsController, type: :controller do
       expect(response_body['jobs'].count).to eq(5)
     end
   end
+
+  describe "GET #show" do
+    let(:response_body) { JSON.parse(response.body) }
+    let(:job) { create(:job) }
+
+    it "is successful" do
+      get :show, id: job.id, format: :json
+
+      expect(:success)
+    end
+
+    it 'returns job with correct attributes' do
+      get :show, id: job.id, format: :json
+      json_job = response_body['job']
+
+      expect(json_job['title']).to be_instance_of(String)
+      expect(json_job['description']).to be_instance_of(String)
+      expect(json_job['url']).to be_instance_of(String)
+      expect(json_job['location']).to be_instance_of(String)
+      expect(json_job['posted_date']).to be_instance_of(String)
+      expect(json_job['remote']).to be false
+      expect(json_job['raw_technologies']).to be_instance_of(Array)
+      expect(json_job['company']).to be_instance_of(Hash)
+    end
+  end
 end


### PR DESCRIPTION
* renders the job object with json
* the responders gem was not being used, so I did not pull it in
   * Should we try to follow the JSON API standards and use a gem like jsonapi-for-rails?

closes #77 