### PR TITLE
Add proper capitalization for tech

### DIFF
--- a/app/serializers/technology_serializer.rb
+++ b/app/serializers/technology_serializer.rb
@@ -1,3 +1,14 @@
 class TechnologySerializer < ActiveModel::Serializer
   attributes :id, :name
+
+  def name
+    tech_capitalizations[object.name] ?
+    tech_capitalizations[object.name] : object.name.capitalize
+  end
+
+  def tech_capitalizations
+    {
+      "javascript" => "JavaScript",
+    }
+  end
 end

--- a/app/serializers/technology_serializer.rb
+++ b/app/serializers/technology_serializer.rb
@@ -3,7 +3,7 @@ class TechnologySerializer < ActiveModel::Serializer
 
   def name
     tech_capitalizations[object.name] ?
-    tech_capitalizations[object.name] : object.name.capitalize
+    tech_capitalizations[object.name] : object.name.split.map(&:capitalize)*' '
   end
 
   def tech_capitalizations

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -47,5 +47,17 @@ RSpec.describe Api::V1::JobsController, type: :controller do
 
       expect(response_body['jobs'].count).to eq(5)
     end
+
+    it 'capitalizes technologies appropriately' do
+      job = create(:job)
+      downcased_technologies = ["javascript", "clojure", "ruby"]
+      downcased_technologies.map {|t| job.technologies << create(:technology, name: t)}
+
+      get :index
+
+      response_body["jobs"].first["technologies"].each_with_index do | tech, i |
+        expect(["JavaScript", "Clojure", "Ruby"]).to include(tech["name"])
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe Api::V1::JobsController, type: :controller do
 
     it 'capitalizes technologies appropriately' do
       job = create(:job)
-      downcased_technologies = ["javascript", "clojure", "ruby"]
+      downcased_technologies = ["javascript", "clojure", "new relic"]
       downcased_technologies.map {|t| job.technologies << create(:technology, name: t)}
 
       get :index
 
       response_body["jobs"].first["technologies"].each_with_index do | tech, i |
-        expect(["JavaScript", "Clojure", "Ruby"]).to include(tech["name"])
+        expect(["JavaScript", "Clojure", "New Relic"]).to include(tech["name"])
       end
     end
   end


### PR DESCRIPTION
Created a method in tech serializer which checks if a given tech is included in a hash of unusually capitalized technology and returns what it should be, or if not included, upcases the technology.

Currently this just affects JavaScript, but this could be relevant should we ever include something like "RSpec" or acronyms. For those cases, they will need to be added to the hash in the serializer as well.

I've also added a quick test for this.

closes #82 @cheljoh 