### PR TITLE
87 job index endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,8 +282,5 @@ DEPENDENCIES
   webmock
   will_paginate-bootstrap
 
-RUBY VERSION
-   ruby 2.3.0p0
-
 BUNDLED WITH
    1.12.5

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -1,10 +1,7 @@
 class Api::V1::JobsController < ApplicationController
 
-  def last_two_months
-    render json: Job.last_two_months
-  end
-
   def index
     paginate json: Job.by_date, per_page: 25
   end
+  
 end

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::JobsController < ApplicationController
 
+  def last_two_months
+    require "pry"; binding.pry
+    render json: Job.last_two_months
+  end
+
   def index
     paginate json: Job.by_date, per_page: 25
   end

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::JobsController < ApplicationController
 
   def last_two_months
-    require "pry"; binding.pry
     render json: Job.last_two_months
   end
 

--- a/app/controllers/api/v1/recent_jobs_controller.rb
+++ b/app/controllers/api/v1/recent_jobs_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::RecentJobsController < ApplicationController
+
+  def index
+    render json: Job.last_two_months
+  end
+  
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -3,6 +3,7 @@ class Job < ActiveRecord::Base
   before_save { |tech| tech.downcase_tech }
 
   scope :by_date, -> { order(posted_date: :desc) }
+  scope :last_two_months, -> { where("posted_date >= ?", 2.months.ago).order(posted_date: :desc) }
   belongs_to :company
   has_and_belongs_to_many :technologies
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :jobs, only: [:index]
-      get '/last_two_months', to: "jobs#last_two_months"
+      get '/recent_jobs', to: "recent_jobs#index"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,65 +1,13 @@
 Rails.application.routes.draw do
-
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
-
-  # You can have the root of your site routed with "root"
   root 'home#index'
 
   resources :jobs, only: [:show]
   resources :companies, only: [:show]
-  
+
   namespace :api do
     namespace :v1 do
       resources :jobs, only: [:index]
+      get '/last_two_months', to: "jobs#last_two_months"
     end
   end
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
 end

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -53,33 +53,48 @@ RSpec.describe Api::V1::JobsController, type: :controller do
     let(:response_body) { json_respone = JSON.parse(response.body) }
 
     it "is successful" do
-      get :index, format: :json
+      get :last_two_months, format: :json
 
       expect(:success)
     end
 
-    # it 'returns jobs with correct attributes' do
-    #   create(:job)
-    #   get :index, format: :json
-    #
-    #   response_body['jobs'].each do |job|
-    #     expect(job['title']).to be_instance_of(String)
-    #     expect(job['description']).to be_instance_of(String)
-    #     expect(job['url']).to be_instance_of(String)
-    #     expect(job['location']).to be_instance_of(String)
-    #     expect(job['posted_date']).to be_instance_of(String)
-    #     expect(job['remote']).to be false
-    #     expect(job['company']).to be_instance_of(Hash)
-    #   end
-    # end
-    #
-    # it 'returns the id and name of the company the job belongs to' do
-    #   create(:job)
-    #   get :index, format: :json
-    #   company = response_body['jobs'].first['company']
-    #
-    #   expect(company['id']).to be_instance_of(Fixnum)
-    #   expect(company['name']).to be_instance_of(String)
-    # end
+    it 'returns jobs with correct attributes' do
+      create(:job)
+      get :last_two_months, format: :json
+
+
+      response_body['jobs'].each do |job|
+        expect(job['title']).to be_instance_of(String)
+        expect(job['description']).to be_instance_of(String)
+        expect(job['url']).to be_instance_of(String)
+        expect(job['location']).to be_instance_of(String)
+        expect(job['posted_date']).to be_instance_of(String)
+        expect(job['remote']).to be false
+        expect(job['company']).to be_instance_of(Hash)
+      end
+    end
+
+    it 'returns the id and name of the company the job belongs to' do
+      create(:job)
+      get :last_two_months, format: :json
+      company = response_body['jobs'].first['company']
+
+      expect(company['id']).to be_instance_of(Fixnum)
+      expect(company['name']).to be_instance_of(String)
+    end
+
+    it 'only returns jobs posted within the last 2 months' do
+      three_month_job = create(:job)
+      three_month_job.update(posted_date: 3.months.ago)
+      two_month_job = create(:job)
+      two_month_job.update(posted_date: 2.months.ago)
+      current_job = create(:job)
+
+      get :last_two_months, format: :json
+
+      expect(response_body['jobs'].count).to eq(2)
+      expect(response_body['jobs'].first["title"]).to eq(current_job.title)
+      expect(response_body['jobs'].last["title"]).to eq(two_month_job.title)
+    end
   end
 end

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -48,4 +48,38 @@ RSpec.describe Api::V1::JobsController, type: :controller do
       expect(response_body['jobs'].count).to eq(5)
     end
   end
+
+  describe "GET #last_two_months" do
+    let(:response_body) { json_respone = JSON.parse(response.body) }
+
+    it "is successful" do
+      get :index, format: :json
+
+      expect(:success)
+    end
+
+    # it 'returns jobs with correct attributes' do
+    #   create(:job)
+    #   get :index, format: :json
+    #
+    #   response_body['jobs'].each do |job|
+    #     expect(job['title']).to be_instance_of(String)
+    #     expect(job['description']).to be_instance_of(String)
+    #     expect(job['url']).to be_instance_of(String)
+    #     expect(job['location']).to be_instance_of(String)
+    #     expect(job['posted_date']).to be_instance_of(String)
+    #     expect(job['remote']).to be false
+    #     expect(job['company']).to be_instance_of(Hash)
+    #   end
+    # end
+    #
+    # it 'returns the id and name of the company the job belongs to' do
+    #   create(:job)
+    #   get :index, format: :json
+    #   company = response_body['jobs'].first['company']
+    #
+    #   expect(company['id']).to be_instance_of(Fixnum)
+    #   expect(company['name']).to be_instance_of(String)
+    # end
+  end
 end

--- a/spec/controllers/api/v1/recent_jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/recent_jobs_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Api::V1::JobsController, type: :controller do
+RSpec.describe Api::V1::RecentJobsController, type: :controller do
 
   describe "GET #index" do
     let(:response_body) { json_response = JSON.parse(response.body) }
@@ -11,18 +11,11 @@ RSpec.describe Api::V1::JobsController, type: :controller do
       expect(:success)
     end
 
-    it 'returns json default of 25 jobs' do
-      30.times { create(:job) }
-      get :index, format: :json
-
-      expect(response_body['jobs'].count).to eq(25)
-    end
-
     it 'returns jobs with correct attributes' do
       create(:job)
       get :index, format: :json
 
-      response_body['jobs'].each do |job|
+      response_body['recent_jobs'].each do |job|
         expect(job['title']).to be_instance_of(String)
         expect(job['description']).to be_instance_of(String)
         expect(job['url']).to be_instance_of(String)
@@ -36,18 +29,25 @@ RSpec.describe Api::V1::JobsController, type: :controller do
     it 'returns the id and name of the company the job belongs to' do
       create(:job)
       get :index, format: :json
-      company = response_body['jobs'].first['company']
+      company = response_body['recent_jobs'].first['company']
 
       expect(company['id']).to be_instance_of(Fixnum)
       expect(company['name']).to be_instance_of(String)
     end
 
-    it 'includes remaining jobs on next page of pagination' do
-      30.times { create(:job) }
-      get :index, page: 2
+    it 'only returns jobs posted within the last 2 months' do
+      three_month_job = create(:job)
+      three_month_job.update(posted_date: 3.months.ago)
+      two_month_job = create(:job)
+      two_month_job.update(posted_date: 2.months.ago)
+      current_job = create(:job)
 
-      expect(response_body['jobs'].count).to eq(5)
+      get :index, format: :json
+
+      expect(response_body['recent_jobs'].count).to eq(2)
+      expect(response_body['recent_jobs'].first["title"]).to eq(current_job.title)
+      expect(response_body['recent_jobs'].last["title"]).to eq(two_month_job.title)
     end
   end
-
+  
 end


### PR DESCRIPTION
@hhoopes @NickyBobby @brennanholtzclaw 

New API endpoint that only returns jobs posted within the last two months. Added new controller tests to verify endpoint. We kept the old endpoint, so now we have a jobs_controller.rb and recent_jobs_controller.rb. New endpoint does not include pagination.