### PR TITLE
Change recent_jobs scope to last month and paginate to 25 per page

### DIFF
--- a/app/controllers/api/v1/recent_jobs_controller.rb
+++ b/app/controllers/api/v1/recent_jobs_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::RecentJobsController < ApplicationController
 
   def index
-    render json: Job.last_two_months
+    paginate json: Job.last_month, per_page: 25
   end
 
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -3,7 +3,7 @@ class Job < ActiveRecord::Base
   before_save { |tech| tech.downcase_tech }
 
   scope :by_date, -> { order(posted_date: :desc) }
-  scope :last_two_months, -> { where("posted_date >= ?", 2.months.ago).order(posted_date: :desc) }
+  scope :last_month, -> { where("posted_date >= ?", 1.month.ago).order(posted_date: :desc) }
   belongs_to :company
   has_and_belongs_to_many :technologies
 

--- a/spec/controllers/api/v1/recent_jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/recent_jobs_controller_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe Api::V1::RecentJobsController, type: :controller do
       expect(company['name']).to be_instance_of(String)
     end
 
-    it 'only returns jobs posted within the last 2 months' do
-      three_month_job = create(:job)
-      three_month_job.update(posted_date: 3.months.ago)
+    it 'only returns jobs posted within the last month' do
       two_month_job = create(:job)
       two_month_job.update(posted_date: 2.months.ago)
+      one_month_job = create(:job)
+      one_month_job.update(posted_date: 1.month.ago)
       current_job = create(:job)
 
       get :index, format: :json
 
       expect(response_body['recent_jobs'].count).to eq(2)
       expect(response_body['recent_jobs'].first["title"]).to eq(current_job.title)
-      expect(response_body['recent_jobs'].last["title"]).to eq(two_month_job.title)
+      expect(response_body['recent_jobs'].last["title"]).to eq(one_month_job.title)
     end
   end
 


### PR DESCRIPTION
Paginating the endpoint to speed up the API call. The previous scope of two months returned > 2000 jobs, so I changed this to scope to only the most recent 1 month. Having > 1000 jobs to look at should be more than sufficient.

closes #91 

@rrgayhart @cheljoh @hhoopes @NickyBobby 