### PR TITLE
Add tech scope to recent jobs

### DIFF
--- a/app/controllers/api/v1/recent_jobs_controller.rb
+++ b/app/controllers/api/v1/recent_jobs_controller.rb
@@ -1,13 +1,9 @@
 class Api::V1::RecentJobsController < ApplicationController
-
   def index
-    if params[:location]
-      search_location = params[:location]
-      jobs_by_location = Job.last_month.by_location(search_location)
-      render json: jobs_by_location
-    else
-      paginate json: Job.last_month, per_page: 25
-    end
-  end
+    jobs = Job.last_month
+    jobs = jobs.merge Job.by_location(params[:location]) if params[:location]
+    jobs = jobs.merge Job.by_tech(params[:technology]) if params[:technology]
 
+    paginate json: jobs, per_page: 25
+  end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -22,6 +22,6 @@ class Job < ActiveRecord::Base
   end
 
   def self.by_tech(tech_name)
-    joins(:technologies).where(technologies: {name: tech_name})
+    joins(:technologies).where(technologies: {name: tech_name.downcase})
   end
 end

--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -48,46 +48,6 @@ RSpec.describe Api::V1::JobsController, type: :controller do
 
       expect(response_body['jobs'].count).to eq(5)
     end
-
-    it 'capitalizes technologies appropriately' do
-      job = create(:job)
-      downcased_technologies = ["javascript", "clojure", "new relic"]
-      downcased_technologies.map {|t| job.technologies << create(:technology, name: t)}
-
-      get :index
-
-      response_body["jobs"].first["technologies"].each_with_index do | tech, i |
-        expect(["JavaScript", "Clojure", "New Relic"]).to include(tech["name"])
-      end
-    end
-
-    it "takes in optional parameters for type of technology" do
-      ruby_job = create(:job)
-      other_job = create(:job)
-      ruby_job.technologies << create(:technology, name: "ruby")
-      other_job.technologies << create(:technology, name: "other")
-
-      get :index, {technology: "ruby"}
-
-      expect(response_body["jobs"].count).to eq(1)
-      response_body["jobs"].each do |job|
-        expect(job["technologies"].first["name"]).to eq("Ruby")
-        expect(job["id"]).to eq(ruby_job.id)
-      end
-    end
-
-    it "returns multiple jobs for technology parameter" do
-      create_list(:job, 4)
-      tech = create(:technology, name: "ruby")
-      Job.find_each {|job| job.technologies << tech}
-
-      get :index, {technology: "ruby"}
-
-      expect(response_body["jobs"].count).to eq(4)
-      response_body["jobs"].each do |job|
-        expect(job["technologies"].first["name"]).to eq("Ruby")
-      end
-    end
   end
 
   describe "GET #show" do


### PR DESCRIPTION
Moved the tech scope over to the recent jobs controller rather than the jobs controller. While this was an easy switch, I also decided to refactor the index action on the recent jobs controller to take fewer lines and allow for scoping by both params at once.

Also added the minor fix of downcasing incoming params for technology. Since we are always storing the technology information ourselves, it didn't require any Active Record params for case-insensitivity.

These cases are also tested.

@cheljoh  Feel free to poke around and make sure it's what you want