### PR TITLE
added time to the sleep timer for the rake task

### DIFF
--- a/lib/tasks/one_off_tasks/fix_location.rake
+++ b/lib/tasks/one_off_tasks/fix_location.rake
@@ -12,7 +12,7 @@ namespace :fix_location do
         check_for_location(job)
       else
         response = Geocoder.search(job.location)
-        sleep 0.25
+        sleep 2
         if response.empty? || response.count > 1 || check_edge_cases(job.location)
           check_for_location(job)
         end
@@ -25,7 +25,7 @@ namespace :fix_location do
     potential_locations = job.title.scan(regex).flatten
     potential_locations.each do |p_loc|
       response = Geocoder.search(p_loc)
-      sleep 0.25
+      sleep 2
       if !response.empty? && response.count == 1 && !check_edge_cases(p_loc)
         return job.update_attributes(location: p_loc)
       else


### PR DESCRIPTION
Hey I just changed the sleep timer from .25 seconds to 2 seconds. So that will be a 2 second delay between each geocoder request. It will take a while to complete but it's fine because it just works in the background. Please merge as soon as you see this so I can run it again. @hhoopes @cheljoh @brennanholtzclaw 