### PR TITLE
Adds Total Pages to Recent Job API Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Ignore coverage folder
 /coverage
+
+.DS_Store

--- a/app/controllers/api/v1/recent_jobs_controller.rb
+++ b/app/controllers/api/v1/recent_jobs_controller.rb
@@ -3,7 +3,8 @@ class Api::V1::RecentJobsController < ApplicationController
     jobs = Job.last_two_months
     jobs = jobs.merge Job.by_location(params[:location]) if params[:location]
     jobs = jobs.merge Job.by_tech(params[:technology]) if params[:technology]
+    num  = 25
 
-    paginate json: jobs, per_page: 25
+    paginate json: jobs, per_page: num, meta: { 'total-pages': Job.total_pages(num) }
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -24,4 +24,8 @@ class Job < ActiveRecord::Base
   def self.by_tech(tech_name)
     joins(:technologies).where(technologies: {name: tech_name.downcase})
   end
+
+  def self.total_pages(num_of_items_per_page)
+     last_two_months.count / num_of_items_per_page
+  end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -26,6 +26,7 @@ class Job < ActiveRecord::Base
   end
 
   def self.total_pages(num_of_items_per_page)
-     last_two_months.count / num_of_items_per_page
+    calculation = last_two_months.count / num_of_items_per_page.to_f
+    calculation.ceil
   end
 end

--- a/spec/controllers/api/v1/recent_jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/recent_jobs_controller_spec.rb
@@ -143,13 +143,13 @@ RSpec.describe Api::V1::RecentJobsController, type: :controller do
     end
 
     it "returns total-pages when api gets called" do
-      create_list(:job, 50)
+      create_list(:job, 55)
       tech = create(:technology, name: "ruby")
       Job.find_each {|job| job.technologies << tech}
 
       get :index, {technology: "ruby"}
 
-      expect(response_body["meta"]["total-pages"]).to eq(2)
+      expect(response_body["meta"]["total-pages"]).to eq(3)
     end
   end
 end

--- a/spec/controllers/api/v1/recent_jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/recent_jobs_controller_spec.rb
@@ -141,5 +141,15 @@ RSpec.describe Api::V1::RecentJobsController, type: :controller do
         expect(job["technologies"].first["name"]).to eq("Ruby")
       end
     end
+
+    it "returns total-pages when api gets called" do
+      create_list(:job, 50)
+      tech = create(:technology, name: "ruby")
+      Job.find_each {|job| job.technologies << tech}
+
+      get :index, {technology: "ruby"}
+
+      expect(response_body["meta"]["total-pages"]).to eq(2)
+    end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -93,4 +93,15 @@ describe Job do
       expect(coords['longitude']).to eq(-74.0059731)
     end
   end
+
+  describe '#total_pages' do
+    it 'returns the total amount of pages' do
+      create_list(:job, 4)
+      tech = create(:technology, name: "ruby")
+      Job.find_each {|job| job.technologies << tech}
+
+      expect(Job.count).to eq(4)
+      expect(Job.total_pages(2)).to eq(2)
+    end
+  end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -96,12 +96,12 @@ describe Job do
 
   describe '#total_pages' do
     it 'returns the total amount of pages' do
-      create_list(:job, 4)
+      create_list(:job, 30)
       tech = create(:technology, name: "ruby")
       Job.find_each {|job| job.technologies << tech}
 
-      expect(Job.count).to eq(4)
-      expect(Job.total_pages(2)).to eq(2)
+      expect(Job.count).to eq(30)
+      expect(Job.total_pages(4)).to eq(8)
     end
   end
 end


### PR DESCRIPTION
@JaredRoth 
Fixes this [issue](https://github.com/LookingForMe/lookingfor/issues/102)

# What does this add?

Adds a 'meta' key to the recent job's API endpoint that returns the total amount
of pages for recent jobs. 

# Requested feedback

* Should I add the same code to the "api/v1/jobscontroller" endpoint? The only reason I didn't do that was because from what Sal said, the front-end team is only hitting our recent job's endpoint.

* Is there a way to have the 'meta' key come before the 'recent_jobs' key from the JSON output when the endpoint gets hit? At the moment 'meta' can only be found when scrolling all the way down.