### PR TITLE
Add d3 data endpoint

### DIFF
--- a/app/controllers/api/v1/trends_controller.rb
+++ b/app/controllers/api/v1/trends_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::TrendsController < ApplicationController
 
   def current_openings_technology_count
-    counts = Job.current_openings_technology_count
-    render json: counts
+    render json: Job.current_openings_technology_count
   end
 end

--- a/app/controllers/api/v1/trends_controller.rb
+++ b/app/controllers/api/v1/trends_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::TrendsController < ApplicationController
 
   def current_openings_technology_count
-    @counts = Job.current_openings_technology_count
-    render json: @counts
+    counts = Job.current_openings_technology_count
+    render json: counts
   end
 end

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::TrendsController < ApplicationController
+
+  def current_openings_technology_count
+    @counts = Job.current_openings_technology_count
+    render json: @counts
+  end
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -32,7 +32,6 @@ class Job < ActiveRecord::Base
   end
 
   def self.current_openings_technology_count
-    # Not the best active record way to do this, obviously
     Technology.all.map do |tech|
       {label: tech.name, value: last_two_months.by_tech(tech.name).count}
     end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -32,4 +32,17 @@ class Job < ActiveRecord::Base
     calculation = last_two_months.count / num_of_items_per_page.to_f
     calculation.ceil
   end
+
+  def self.technologies_by_month
+    # Will serve as a trailing data set (for 6 months or whatever the limit is)
+    # For each month, count the number of job postings that contain a certain technology
+    # Export some array like:
+    # [[Technology Headers],
+    # [month_date1, tech1_num, tech2_num],
+    # [month_date2, tech1_num, tech2_num],
+    # [month_date3, tech1_num, tech2_num],
+    # [.],
+    # [.],
+    # [.]]
+  end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -10,8 +10,6 @@ class Job < ActiveRecord::Base
   belongs_to :location
 
   def self.by_location(search_location)
-    # where("lower(location) LIKE ?", "%#{search_location.downcase}%")
-    # binding.pry
     joins(:location).where("lower(name) LIKE ?", "%#{search_location.downcase}%")
   end
 
@@ -33,16 +31,8 @@ class Job < ActiveRecord::Base
     calculation.ceil
   end
 
-  def self.technologies_by_month
-    # Will serve as a trailing data set (for 6 months or whatever the limit is)
-    # For each month, count the number of job postings that contain a certain technology
-    # Export some array like:
-    # [[Technology Headers],
-    # [month_date1, tech1_num, tech2_num],
-    # [month_date2, tech1_num, tech2_num],
-    # [month_date3, tech1_num, tech2_num],
-    # [.],
-    # [.],
-    # [.]]
+  def self.current_openings_technology_count
+    # This is for all jobs...not dependent on the date
+    group(:raw_technologies).count
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -34,7 +34,7 @@ class Job < ActiveRecord::Base
   def self.current_openings_technology_count
     # Not the best active record way to do this, obviously
     Technology.all.map do |tech|
-      [tech.name, last_two_months.by_tech(tech.name).count]
+      {label: tech.name, value: last_two_months.by_tech(tech.name).count}
     end
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -32,7 +32,9 @@ class Job < ActiveRecord::Base
   end
 
   def self.current_openings_technology_count
-    # This is for all jobs...not dependent on the date
-    group(:raw_technologies).count
+    # Not the best active record way to do this, obviously
+    Technology.all.map do |tech|
+      [tech.name, last_two_months.by_tech(tech.name).count]
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resources :jobs, only: [:index, :show]
       resources :companies, only: [:show]
       get '/recent_jobs', to: "recent_jobs#index"
+      get '/current_openings_technology_count', to: "trends#current_openings_technology_count"
     end
   end
 end

--- a/spec/controllers/api/v1/trends_controller_spec.rb
+++ b/spec/controllers/api/v1/trends_controller_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe Api::V1::TrendsController, type: :controller do
 
       get :current_openings_technology_count, format: :json
 
-      expect(response_body['trends'].count).to eq(2)
-      expect(response_body['trends'][0]).to eq([tech1.name, 1])
-      expect(response_body['trends'][1]).to eq([tech2.name, 2])
+      trends = response_body['trends']
+
+      expect(trends.count).to eq(2)
+      expect(trends[0]).to eq([tech1.name, 1])
+      expect(trends[1]).to eq([tech2.name, 2])
     end
   end
 end

--- a/spec/controllers/api/v1/trends_controller_spec.rb
+++ b/spec/controllers/api/v1/trends_controller_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Api::V1::TrendsController, type: :controller do
       trends = response_body['trends']
 
       expect(trends.count).to eq(2)
-      expect(trends[0]).to eq([tech1.name, 1])
-      expect(trends[1]).to eq([tech2.name, 2])
+      expect(trends[0]).to eq({"label" => tech1.name, "value" => 1})
+      expect(trends[1]).to eq({"label" => tech2.name, "value" => 2})
     end
   end
 end

--- a/spec/controllers/api/v1/trends_controller_spec.rb
+++ b/spec/controllers/api/v1/trends_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::TrendsController, type: :controller do
+
+  describe "GET #current_openings_technology_count" do
+
+    let(:response_body) { JSON.parse(response.body) }
+
+    it "is successful" do
+      get :current_openings_technology_count, format: :json
+
+      expect(:success)
+    end
+
+    it 'returns technologies and counts' do
+      job1 = create(:job)
+      job2 = create(:job)
+      job3 = create(:job)
+      job3.raw_technologies = job2.raw_technologies
+      tech1 = Technology.create(name: job1.raw_technologies[0])
+      tech2 = Technology.create(name: job2.raw_technologies[0])
+      job1.assign_tech
+      job2.assign_tech
+      job3.assign_tech
+
+      get :current_openings_technology_count, format: :json
+
+      expect(response_body['trends'].count).to eq(2)
+      expect(response_body['trends'][0]).to eq([tech1.name, 1])
+      expect(response_body['trends'][1]).to eq([tech2.name, 2])
+    end
+  end
+end


### PR DESCRIPTION
This change is part of a project to add data visualizations of job postings to the front-end side of LookingFor. I have added a model method that counts the number of job openings from the previous two months for each technology.

The model method is called in the API endpoint of the same name (current_openings_technology_count).

The format of the method output looks unusual, but it is deliberately based on what is needed on the front-end site to render the rd3 treemap.

I have also added a request test to be sure the endpoint works as it should and returns the JSON format I expect for the front-end.